### PR TITLE
msys2 bash shelll command "login" functionality is fixed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ build_script:
   - cd OpenBLAS
   - cp ../make/Makefile.rule .
   - SET PATH=C:\msys64\usr\bin
-  - bash -l ..\scripts\build.sh
+  - bash ..\scripts\build.sh
 
 test_script:
   - echo Running Test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ build_script:
   - cd OpenBLAS
   - cp ../make/Makefile.rule .
   - SET PATH=C:\msys64\usr\bin
-  - bash -l ../scripts/build.sh
+  - bash -l ..\scripts\build.sh
 
 test_script:
   - echo Running Test


### PR DESCRIPTION
So now, you don't need a "-l" when you want to run a relative script.